### PR TITLE
Add status code from response object to pass along

### DIFF
--- a/src/Middleware/ResourceToOutput.php
+++ b/src/Middleware/ResourceToOutput.php
@@ -46,7 +46,7 @@ class ResourceToOutput
      */
     protected function toJSON(ResourceResponse $response)
     {
-        return \Response::json($response->getResource()->toArray());
+        return \Response::json($response->getResource()->toArray(), $response->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
If the status code is set in the response object - in my case 204 No Content - the response still returns 200 ok in json.