### PR TITLE
Added JSON_UNESCAPED_SLASHES to avoid slashes in urls

### DIFF
--- a/src/Middleware/ResourceToOutput.php
+++ b/src/Middleware/ResourceToOutput.php
@@ -50,7 +50,7 @@ class ResourceToOutput
      */
     protected function toJSON(ResourceResponse $response)
     {
-        return \Response::json($response->getResource()->toArray(), $response->getStatusCode());
+        return \Response::json($response->getResource()->toArray(), $response->getStatusCode(), [], JSON_UNESCAPED_SLASHES);
     }
 
     /**


### PR DESCRIPTION
Urls are now returned this way:
http:\/\/www.tui.be.test\/nl\/hotel\/spanje\/tenerife\/jardin-tropical-02933?datefrom=20191020&dateto=20191030&adults=2

I need them without the slashes, so client can use them directly.

